### PR TITLE
Supports pep257 over 0.4.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     py_modules=['pytest_pep257'],
     install_requires=[
         'pytest>=2.6.0',
-        'pep257>=0.3.2,<0.4.0'
+        'pep257>=0.3.2'
     ],
     entry_points={'pytest11': ['pytest_pep257 = pytest_pep257']},
     license='MIT License'


### PR DESCRIPTION
  The current version of pep257 is 0.5.0,
  but pytest-pep257 specifies `pep257>=0.3.2,<0.4.0`.
  I have tested pytest-pep257 with pep257 0.5.0.
  This changes removing `<0.4.0`.

Signed-off-by: Kouhei Maeda mkouhei@palmtb.net
